### PR TITLE
Store allocations for checkings in GC Moves and Heapshot events

### DIFF
--- a/src/Event.cs
+++ b/src/Event.cs
@@ -136,6 +136,7 @@ namespace Mono.Profiling
 		Runtime = 1 << 13,
 		System = 1 << 14,
 		PerfCounters = 1 << 15,
+		Profiler = 1 << 16
 	}
 
 	public enum CounterType {


### PR DESCRIPTION
This increases drastically the number of errors the Linter finds though:

```
events:2894114 ignored:34617 errors: 655987
```

I think this is due to the GcMove events coming out of sync (https://bugzilla.xamarin.com/show_bug.cgi?id=38749)
